### PR TITLE
Updated Package Metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ build:
 	python setup.py sdist bdist_wheel
 
 release-test: clean build
-	twine upload -r pypitest dist/aws-rds-manager-*
+	twine upload -r pypitest dist/aws*
 
 release: clean build
-	twine upload -r pypi dist/aws-rds-manager-*
+	twine upload -r pypi dist/aws*
 
 test: clean
 	tox

--- a/README.rst
+++ b/README.rst
@@ -2,17 +2,17 @@
   :target: https://badge.fury.io/py/aws-rds-manager
 
 .. image:: https://img.shields.io/pypi/pyversions/aws-rds-manager.svg
-  :target: https://pypi.python.org/pypi/aws-rds-manager/1.0.2
+  :target: https://pypi.python.org/pypi/aws-rds-manager
 
-.. image:: https://www.quantifiedcode.com/api/v1/project/d0e2098bfb494a17b26851c590681005/badge.svg
-  :target: https://www.quantifiedcode.com/app/project/d0e2098bfb494a17b26851c590681005
+.. image:: https://www.quantifiedcode.com/api/v1/project/cc9c76aff11b4442b0dae86ffdd9d69f/badge.svg
+  :target: https://www.quantifiedcode.com/app/project/cc9c76aff11b4442b0dae86ffdd9d69f
   :alt: Code issues
 
-.. image:: https://travis-ci.org/drewsonne/aws-rds-manager.svg?branch=master
-  :target: https://travis-ci.org/drewsonne/aws-rds-manager
+.. image:: https://travis-ci.org/nordcloud/aws-rds-manager.svg?branch=master
+  :target: https://travis-ci.org/nordcloud/aws-rds-manager
 
-.. image:: https://codecov.io/gh/drewsonne/aws-rds-manager/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/drewsonne/aws-rds-manager
+.. image:: https://codecov.io/gh/nordcloud/aws-rds-manager/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/nordcloud/aws-rds-manager
 
 ===============
 aws-rds-manager

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal=1
+
+[wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,16 @@
 from setuptools import find_packages, setup
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 setup(
     name='aws-rds-manager',
     description='CLI tool providing sunsetting of RDS snapshots',
+    url='https://github.com/nordcloud/aws-rds-manager',
     long_description=open('README.rst').read(),
     version=__version__,
     packages=['awsrdsmanager'],
-    download_url='https://github.com/drewsonne/aws-rds-manager/archive/v.{version}.tar.gz'.format(version=__version__),
+    download_url='https://github.com/nordcloud/aws-rds-manager/archive/v.{version}.tar.gz'.format(version=__version__),
     install_requires=['aws-auth-helper', 'six'],
-    url='',
     license='GPLv2',
     test_suite='tests',
     author='Drew J. Sonne',


### PR DESCRIPTION
 - Fixed links in package metadata and readme, which were pointing to [drewsonne](https://github.com/drewsonne), instead of [nordcloud](https://github.com/nordcloud).
 - Fixed a bug where setup.py wasn't able to upload wheel to [pypi.python.org](https://pypi.python.org/pypi).